### PR TITLE
chore(deps): bump @actions/core to 2.0.3 and @actions/github to 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@actions/github": "^6.0.1",
+        "@actions/core": "^2.0.3",
+        "@actions/github": "^7.0.0",
         "@grpc/grpc-js": "^1.14.1",
         "@yandex-cloud/nodejs-sdk": "^2.9.0",
         "axios": "^1.18.1",
@@ -46,31 +46,31 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-Od9Thc3T1mQJYddvVPM4QGiLUewdh+3txmDYHHxoNdkqysR1MbCT+rFOtNUxYAz+7+6RIsqipVahY2GJqGPyxA==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^1.1.1",
-        "@actions/http-client": "^2.0.1"
+        "@actions/exec": "^2.0.0",
+        "@actions/http-client": "^3.0.2"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-2.0.0.tgz",
+      "integrity": "sha512-k8ngrX2voJ/RIN6r9xB82NVqKpnMRtxDoiO+g3olkIUpQNqjArXrCQceduQZCQj3P3xm32pChRLqRrtXTlqhIw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^1.0.1"
+        "@actions/io": "^2.0.0"
       }
     },
     "node_modules/@actions/github": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
-      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-7.0.0.tgz",
+      "integrity": "sha512-PyGODO938aoBTZd/IfN/+e+Pd5hUcVpyf+thm4CPESLeqhdSkq5QwMTGX9v84XHE1ifmHWBQ60KB8kIgm96opw==",
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.2.0",
+        "@actions/http-client": "^3.0.1",
         "@octokit/core": "^5.0.1",
         "@octokit/plugin-paginate-rest": "^9.2.2",
         "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
@@ -80,19 +80,19 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-2.0.0.tgz",
+      "integrity": "sha512-Jv33IN09XLO+0HS79aaODsvIRyduiF7NY/F6LYeK5oeUmrsz7aFdRphQjFoESF4jS7lMauDOttKALcpapVDIAg==",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -613,9 +613,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     ]
   },
   "dependencies": {
-    "@actions/core": "^1.11.1",
-    "@actions/github": "^6.0.1",
+    "@actions/core": "^2.0.3",
+    "@actions/github": "^7.0.0",
     "@grpc/grpc-js": "^1.14.1",
     "@yandex-cloud/nodejs-sdk": "^2.9.0",
     "axios": "^1.18.1",


### PR DESCRIPTION
Aligns this action with the rest of the `yc-actions` org. `yc-coi-deploy`, `yc-sls-container-deploy` and `yc-sls-function` all sit on `@actions/core` ^2.x + `@actions/github` ^7.0.0 — this repo was still on 1.11.1 / 6.0.1.

## Why not go further

These are the highest majors that still work under the current CJS Jest setup. The `@actions/*` line crossed into ESM-only territory:

| Package | Last CJS-safe | Breaks because |
| --- | --- | --- |
| `@actions/core` | **2.0.3** | 3.0.0+ is `"type": "module"` with import-only exports — ts-jest cannot resolve it |
| `@actions/github` | **7.0.0** | 8.x is itself CJS but depends on ESM-only `@octokit/core`, which fails to parse under Jest; 9.0.0+ is fully ESM-only |

The v8 case is the subtle one — it typechecks and bundles fine, then Jest dies at `node_modules/@octokit/core/dist-src/index.js:1` via `@actions/github/src/utils.ts`.

Note that `yc-lockbox` and `yc-obj-storage-upload` do declare `@actions/github` v9, but neither actually imports it, so Jest never resolves it and the problem never surfaces. Every repo that does import it stopped at 7.0.0.

Going higher requires migrating the package and test setup to ESM (`"type": "module"`, `module: NodeNext`, Jest in ESM mode or a swap to Vitest). No repo in the org has done that yet, so there is no prior art to copy.

## Verification

| Combination | tsc | jest | ncc bundle |
| --- | --- | --- | --- |
| core 1.11.1 + github 6.0.1 (main today) | ✅ | ✅ 6/6 | ✅ |
| **core 2.0.3 + github 7.0.0 (this PR)** | ✅ | ✅ **6/6** | ✅ |
| core 2.0.3 + github 8.0.1 | ✅ | ❌ `@octokit/core` parse error | ✅ |
| core 3.0.0 (#758) | ✅ | ❌ cannot resolve | ✅ |
| github 9.0.0 (#759) | ✅ | ❌ cannot resolve | ✅ |

`npm run all` passes locally, coverage is unchanged at 73.75%, and `dist/` is reproducible so `check-dist` should be green.

No source changes were needed — the bump is API-compatible.

## Supersedes

Closes #758 and closes #759, both of which are red on `build` for exactly the ESM reason above and have been stale since February.